### PR TITLE
fix to process from opcodes string, not just OpcodesInterfaces

### DIFF
--- a/src/cogpowered/FineDiff/Render/Renderer.php
+++ b/src/cogpowered/FineDiff/Render/Renderer.php
@@ -6,8 +6,8 @@
  * Computes a set of instructions to convert the content of
  * one string into another.
  *
- * Originally created by Raymond Hill (github.com/gorhill/PHP-FineDiff), brought up
- * to date by Cog Powered (github.com/cogpowered/FineDiff).
+ * Originally created by Raymond Hill (https://github.com/gorhill/PHP-FineDiff), brought up
+ * to date by Cog Powered (https://github.com/cogpowered/FineDiff).
  *
  * @copyright Copyright 2011 (c) Raymond Hill (http://raymondhill.net/blog/?p=441)
  * @copyright Copyright 2013 (c) Robert Crowe (http://cogpowered.com)

--- a/src/cogpowered/FineDiff/Render/RendererInterface.php
+++ b/src/cogpowered/FineDiff/Render/RendererInterface.php
@@ -6,8 +6,8 @@
  * Computes a set of instructions to convert the content of
  * one string into another.
  *
- * Originally created by Raymond Hill (github.com/gorhill/PHP-FineDiff), brought up
- * to date by Cog Powered (github.com/cogpowered/FineDiff).
+ * Originally created by Raymond Hill (https://github.com/gorhill/PHP-FineDiff), brought up
+ * to date by Cog Powered (https://github.com/cogpowered/FineDiff).
  *
  * @copyright Copyright 2011 (c) Raymond Hill (http://raymondhill.net/blog/?p=441)
  * @copyright Copyright 2013 (c) Robert Crowe (http://cogpowered.com)


### PR DESCRIPTION
Hi Rob, I'm playing around with decoding previous versions of articles stored as opcode-strings in a database, so I needed to be able to pass the opcodes-string as the second argument to <code>Render::process()</code>. Also, the example in the README shows this functionality, so I thought it would be a good idea to add a pull request on this.

PS. Something weird happened in the docblock (misspelled as 'codeblock' in the commit message), which is why I ended up doing 3 commits..
