### PR TITLE
Ensure compatibility with PHP < 5.3.9

### DIFF
--- a/src/cogpowered/FineDiff/Granularity/GranularityInterface.php
+++ b/src/cogpowered/FineDiff/Granularity/GranularityInterface.php
@@ -20,11 +20,6 @@ namespace cogpowered\FineDiff\Granularity;
 
 interface GranularityInterface
 {
-    public function offsetExists($offset);
-    public function offsetGet($offset);
-    public function offsetSet($offset, $value);
-    public function offsetUnset($offset);
-
     /**
      * Get the delimiters that make up the granularity.
      *


### PR DESCRIPTION
Prior to PHP 5.3.9 a class could not implement two interfaces if they contained a method with the same name (see first note at http://php.net/manual/en/language.oop5.interfaces.php).

The Granularity class implements both GranularityInterface and ArrayAccess and they both specify the set of offset* methods, so this results in a fatal error when running on PHP < 5.3.9 (I tested it on PHP 5.3.3). There's really no need to specify this methods in GranularityInterface, given that they're already defined in ArrayAccess.